### PR TITLE
Add main agents overview diagram

### DIFF
--- a/diagrams/main_agents_overview.mmd
+++ b/diagrams/main_agents_overview.mmd
@@ -1,0 +1,39 @@
+```mermaid
+flowchart TD
+    RA[Requirement Analyst]
+    SA[System Architect]
+    IA[Implementation Agent]
+    CR[Code Reviewer]
+    QA[Quality Assurance Agent]
+    VA[Validator]
+    DEP[Deployment Orchestrator]
+    SEC[Security Agent]
+    DOC[Documentation Agent]
+    MM[Memory Manager]
+    KR[Knowledge Retriever]
+
+    RA --> SA --> IA --> CR --> QA --> VA --> DEP
+
+    RA --> MM
+    SA --> MM
+    IA --> MM
+    QA --> MM
+    VA --> MM
+    SEC --> MM
+    DOC --> MM
+    MM --> IA
+    MM --> QA
+    MM --> DOC
+
+    QA --> DOC
+    CR --> DOC
+
+    SEC --> IA
+    SEC --> DEP
+
+    KR -.-> RA
+    KR -.-> SA
+    KR -.-> IA
+    KR -.-> SEC
+    KR -.-> DOC
+```


### PR DESCRIPTION
## Summary
- add a concise mermaid diagram highlighting the main agents and their primary hand-offs
- capture supporting relationships to the Memory Manager, Security Agent, Documentation Agent, and Knowledge Retriever

## Testing
- not run (diagram-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cc5f759a3883319643438d06cee5e1